### PR TITLE
fix: Add contents write permissions to GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - "v*"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
- Fixes 'Resource not accessible by integration' error
- Allows workflow to create GitHub releases automatically
- Required for softprops/action-gh-release@v1 to work properly